### PR TITLE
Remove VTI Theme (New design)

### DIFF
--- a/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-openwebif-extras.bb
+++ b/recipes-openpli/enigma2-plugins/enigma2-plugin-extensions-openwebif-extras.bb
@@ -23,8 +23,20 @@ PKGV = "1+git${GITPKGV}"
 
 require ../../../meta-openpli/recipes-openpli/e2openplugins/openplugins-distutils.inc
 
+# Remove VTI Theme To save some free space on flash for devices which have small flash
+REMOVE_VTI_THEME = "\ 
+	            rm -rf ${S}/plugin/controllers/views/responsive \
+	            rm -rf ${S}/plugin/public/themes/absb \
+	            rm -rf ${S}/plugin/public/css/vti* \
+	            rm -rf ${S}/plugin/public/js/vti* \
+	            rm -rf ${S}/plugin/public/js/openwebif-1.2.14.min.js \
+	            rm -rf ${S}/plugin/public/js/openwebif-1.2.10.min.js \
+	            rm -rf ${S}/plugin/public/js/chosen.jquery.min.js \
+"
+
 # Just a quick hack to "compile" it
 do_compile() {
+        ${@bb.utils.contains("MACHINE_FEATURES", "smallflash", "${REMOVE_VTI_THEME}" , "", d)}
 	cheetah-compile -R --nobackup ${S}/plugin
 	python -O -m compileall ${S}
 }


### PR DESCRIPTION
After last commit
https://github.com/PLi-metas/pli-extras/commit/0f0f068e9f674577cebdcde84082f85316ce943c#diff-147e5a8e0a6ca7a34b73f60ac3f1a1f7
Plugin after compiled comes 10MB

So this commit delete New design and save 5MB free space in flash To devices have small flash such as dm800, 800se ..etc